### PR TITLE
Update flask_example.py

### DIFF
--- a/docs/examples/opentelemetry-example-app/src/opentelemetry_example_app/flask_example.py
+++ b/docs/examples/opentelemetry-example-app/src/opentelemetry_example_app/flask_example.py
@@ -25,7 +25,7 @@ from opentelemetry.instrumentation.flask import FlaskInstrumentor
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import (
     ConsoleSpanExporter,
-    SimpleExportSpanProcessor,
+    SimpleSpanProcessor,
 )
 
 # The preferred tracer implementation must be set, as the opentelemetry-api
@@ -36,7 +36,7 @@ trace.set_tracer_provider(TracerProvider())
 opentelemetry.instrumentation.requests.RequestsInstrumentor().instrument()
 
 trace.get_tracer_provider().add_span_processor(
-    SimpleExportSpanProcessor(ConsoleSpanExporter())
+    SimpleSpanProcessor(ConsoleSpanExporter())
 )
 
 app = flask.Flask(__name__)


### PR DESCRIPTION
# Description

SimpleExportSpanProcessor has been renamed to SimpleSpanProcessor as of https://github.com/open-telemetry/opentelemetry-python/blob/main/CHANGELOG.md#version-100-2021-03-26
Minor update to new exporter name.

Fixes # 
Traceback (most recent call last):
  File "/Users/eddie/dev/trace_response/trace_response.py", line 9, in <module>
    from opentelemetry.sdk.trace.export import (
ImportError: cannot import name 'SimpleExportSpanProcessor' from 'opentelemetry.sdk.trace.export' (/opt/homebrew/lib/python3.10/site-packages/opentelemetry/sdk/trace/export/__init__.py)


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on Python 3.10 running on MacOS Ventura with the latest OpenTelemetry SDK - this change was as of version 1.0 of the Opentelemetry SDK. 

- [x] Test A

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
