### PR TITLE
Fix tracing_example.py to use correct class

### DIFF
--- a/docs/getting_started/tracing_example.py
+++ b/docs/getting_started/tracing_example.py
@@ -17,12 +17,12 @@ from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import (
     ConsoleSpanExporter,
-    SimpleExportSpanProcessor,
+    SimpleSpanProcessor,
 )
 
 trace.set_tracer_provider(TracerProvider())
 trace.get_tracer_provider().add_span_processor(
-    SimpleExportSpanProcessor(ConsoleSpanExporter())
+    SimpleSpanProcessor(ConsoleSpanExporter())
 )
 
 tracer = trace.get_tracer(__name__)


### PR DESCRIPTION
# Description

The current code example for tracing is not working. Instead of using `SimpleSpanProcessor` the code is using an old `SimpleExportSpanProcessor` which does not exists anymore. This change replace it with the correct one to make the example execute successfully again.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Executed code with and without the change.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [x] Documentation has been updated
